### PR TITLE
Fix for wrong wordcloud filtering

### DIFF
--- a/src/Board.js
+++ b/src/Board.js
@@ -113,7 +113,13 @@ class Board extends React.Component {
     const rows =
       (events &&
         orderBy(
-          events.filter(event => event.name.includes(table.tableFilterText)),
+          table.tableFilterText
+            ? events.filter(
+                event =>
+                  event.tags.filter(tag => table.tableFilterText === tag.label)
+                    .length
+              )
+            : events,
           sortCol === "date" ? "dateFrom" : sortCol,
           sortDir
         )) ||


### PR DESCRIPTION
On click of wordcloud tags, the matching is now done between event tags and not event name
Issue : https://github.com/code-for-cause/tech-conferences/issues/18